### PR TITLE
add sudo to readlink and test -e commands

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
+++ b/lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
 
           # If the path doesn't exist at all in the machine then we
           # can safely say it is not mounted
-          exists = machine.communicate.test("test -e #{guest_path}")
+          exists = machine.communicate.test("test -e #{guest_path}", sudo: true)
           return false unless exists
 
           # find the absolute path so that we can properly check if it is mounted

--- a/lib/vagrant-sshfs/cap/guest/linux/sshfs_get_absolute_path.rb
+++ b/lib/vagrant-sshfs/cap/guest/linux/sshfs_get_absolute_path.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class SSHFSGetAbsolutePath
         def self.sshfs_get_absolute_path(machine, path)
           abs_path = ""
-          machine.communicate.execute("readlink -f #{path}") do |type, data|
+          machine.communicate.execute("readlink -f #{path}", sudo: true) do |type, data|
             if type == :stdout
               abs_path = data
             end


### PR DESCRIPTION
In b3eae35 and a4abb8a we added some attempt to resolve the
path of symbolic links and also a check to make sure a file path
exists before checking it. The commands we used for that don't run
privileged by default, which causes failures if you try to mount
under a directory owned by root.

Fixes #65