### PR TITLE
Support proxy mode for ssh connectivity

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
+++ b/lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
@@ -209,6 +209,12 @@ module VagrantPlugins
           ssh_opts+= ' -o "IdentityFile=\"' + machine.ssh_info[:private_key_path][0] + '\""'
           ssh_opts+= ' -o UserKnownHostsFile=/dev/null '
           ssh_opts+= ' -F /dev/null ' # Don't pick up options from user's config
+
+          # Use an SSH ProxyCommand when corresponding Vagrant setting is defined
+          if machine.ssh_info[:proxy_command]
+            ssh_opts+= " -o ProxyCommand=\"" + machine.ssh_info[:proxy_command] + "\""
+          end
+
           ssh_cmd = ssh_path + ssh_opts + ' ' + ssh_opts_append + ' ' + machine.ssh_info[:host]
           ssh_cmd+= ' "' + sshfs_cmd + '"'
 


### PR DESCRIPTION
This is useful when running boxes on a remote hypervisor exposed via ssh
(f.e. libvirt), where connection to the box is proxied through the
hypervisor node.

Closes dustymabe/vagrant-sshfs#75