### PR TITLE
Add freebsd support

### DIFF
--- a/features/sshfs_cwd_mount.feature
+++ b/features/sshfs_cwd_mount.feature
@@ -3,9 +3,9 @@
 # human readable. All Gherkin files have a .feature extension
 #
 # See more here: https://en.wikipedia.org/wiki/Cucumber_(software)
-# 
-# Additoinally in the setup/env.rb file we set up Aruba. Aruba is used 
-# to define most of the basic step definitions that we use as part of 
+#
+# Additoinally in the setup/env.rb file we set up Aruba. Aruba is used
+# to define most of the basic step definitions that we use as part of
 # the Gherkin syntax in this file.
 #
 # For more information on the step definitions provided see:
@@ -21,7 +21,7 @@ Feature: SSHFS mount of vagrant current working directory
       # Disable the default rsync
       config.vm.synced_folder '.', '/vagrant', disabled: true
 
-      # If using libvirt and nested virt (vagrant in vagrant) then 
+      # If using libvirt and nested virt (vagrant in vagrant) then
       # we need to use a different network than 192.168.121.0
       config.vm.provider :libvirt do |libvirt|
         libvirt.management_network_name = 'vagrant-libvirt-test'
@@ -42,5 +42,5 @@ Feature: SSHFS mount of vagrant current working directory
     Examples:
       | box      |
       | centos/7 |
-    
-    
+
+

--- a/features/step_definitions/sshfs_cwd_mount_steps.rb
+++ b/features/step_definitions/sshfs_cwd_mount_steps.rb
@@ -1,6 +1,6 @@
-# This is a cucumber step definition. Cucumber scenarios become automated 
-# tests with the addition of what are called step definitions. A step 
-# definition is a block of code associated with one or more steps by a 
+# This is a cucumber step definition. Cucumber scenarios become automated
+# tests with the addition of what are called step definitions. A step
+# definition is a block of code associated with one or more steps by a
 # regular expression (or, in simple cases, a string).
 #
 # This is the step definition for the `And vagrant current working

--- a/lib/vagrant-sshfs.rb
+++ b/lib/vagrant-sshfs.rb
@@ -4,8 +4,8 @@ rescue LoadError
   raise "The Vagrant sshfs plugin must be run within Vagrant"
 end
 
-# Only load the gem on Windows since it replaces some methods in Ruby's 
-# Process class. Also load it here before Process.uid is called the first 
+# Only load the gem on Windows since it replaces some methods in Ruby's
+# Process class. Also load it here before Process.uid is called the first
 # time by Vagrant. The Process.create() function actually gets used in
 # lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
 if Vagrant::Util::Platform.windows?

--- a/lib/vagrant-sshfs/cap/guest/freebsd/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/freebsd/sshfs_client.rb
@@ -1,0 +1,22 @@
+module VagrantPlugins
+  module GuestFreeBSD
+    module Cap
+      class SSHFSClient
+        def self.sshfs_install(machine)
+          machine.communicate.sudo("pkg install -y fusefs-sshfs")
+          machine.communicate.sudo("kldload fuse")
+        end
+
+        def self.sshfs_installed(machine)
+          installed = machine.communicate.test("pkg info fusefs-sshfs")
+          if installed
+              # fuse may not get loaded at boot, so check if it's loaded otherwise force load it
+              machine.communicate.sudo("kldstat -m fuse || kldload fuse")
+          end
+
+          installed
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-sshfs/cap/guest/freebsd/sshfs_forward_mount.rb
+++ b/lib/vagrant-sshfs/cap/guest/freebsd/sshfs_forward_mount.rb
@@ -1,0 +1,13 @@
+require_relative "../linux/sshfs_forward_mount"
+
+module VagrantPlugins
+  module GuestFreeBSD
+    module Cap
+      class MountSSHFS < VagrantPlugins::GuestLinux::Cap::MountSSHFS
+        def self.list_mounts_command
+          "mount -p"
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
+++ b/lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
@@ -16,6 +16,10 @@ module VagrantPlugins
         extend Vagrant::Util::Retryable
         @@logger = Log4r::Logger.new("vagrant::synced_folders::sshfs_mount")
 
+        def self.list_mounts_command
+          "cat /proc/mounts"
+        end
+
         def self.sshfs_forward_is_folder_mounted(machine, opts)
           mounted = false
           guest_path = opts[:guestpath]
@@ -31,7 +35,7 @@ module VagrantPlugins
             :sshfs_get_absolute_path, guest_path)
 
           # consult /proc/mounts to see if it is mounted or not
-          machine.communicate.execute("cat /proc/mounts") do |type, data|
+          machine.communicate.execute(self.list_mounts_command) do |type, data|
             if type == :stdout
               data.each_line do |line|
                 if line.split()[1] == absolute_guest_path

--- a/lib/vagrant-sshfs/cap/guest/redhat/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/redhat/sshfs_client.rb
@@ -3,7 +3,7 @@ module VagrantPlugins
     module Cap
       class SSHFSClient
         def self.sshfs_install(machine)
-          # Install epel rpm if not installed 
+          # Install epel rpm if not installed
           if !epel_installed(machine)
             epel_install(machine)
           end
@@ -15,7 +15,7 @@ module VagrantPlugins
         def self.sshfs_installed(machine)
           machine.communicate.test("rpm -q fuse-sshfs")
         end
-        
+
         protected
 
         def self.epel_installed(machine)
@@ -26,7 +26,7 @@ module VagrantPlugins
           case machine.guest.capability("flavor")
             when :rhel_7
               machine.communicate.sudo("rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm")
-            when :rhel # rhel6 
+            when :rhel # rhel6
               machine.communicate.sudo("rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm")
           end
         end

--- a/lib/vagrant-sshfs/cap/host/darwin/sshfs_reverse_mount.rb
+++ b/lib/vagrant-sshfs/cap/host/darwin/sshfs_reverse_mount.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
           # opts contains something like:
           #   { :type=>:sshfs,
           #     :guestpath=>"/sharedfolder",
-          #     :hostpath=>"/guests/sharedfolder", 
+          #     :hostpath=>"/guests/sharedfolder",
           #     :disabled=>false
           #     :ssh_host=>"192.168.1.1"
           #     :ssh_port=>"22"
@@ -46,7 +46,7 @@ module VagrantPlugins
 
         protected
 
-        # Perform a mount by running an sftp-server on the vagrant host 
+        # Perform a mount by running an sftp-server on the vagrant host
         # and piping stdin/stdout to sshfs running inside the guest
         def self.sshfs_mount(machine, opts)
 
@@ -64,7 +64,7 @@ module VagrantPlugins
           opts[:sshfs_opts] = ' -o noauto_cache '# disable caching based on mtime
 
           # Add in some ssh options that are common to both mount methods
-          opts[:ssh_opts] = ' -o StrictHostKeyChecking=no '# prevent yes/no question 
+          opts[:ssh_opts] = ' -o StrictHostKeyChecking=no '# prevent yes/no question
           opts[:ssh_opts]+= ' -o ServerAliveInterval=30 '  # send keepalives
 
           # SSH connection options
@@ -88,12 +88,12 @@ module VagrantPlugins
           # The sshfs command to mount the guest directory on the host
           sshfs_cmd = "#{sshfs_path} #{ssh_opts} #{ssh_opts_append} "
           sshfs_cmd+= "#{sshfs_opts} #{sshfs_opts_append} "
-          sshfs_cmd+= "#{username}@#{host}:#{expanded_guest_path} #{hostpath}" 
+          sshfs_cmd+= "#{username}@#{host}:#{expanded_guest_path} #{hostpath}"
 
           # Log some information
           @@logger.debug("sshfs cmd: #{sshfs_cmd}")
 
-          machine.ui.info(I18n.t("vagrant.sshfs.actions.reverse_mounting_folder", 
+          machine.ui.info(I18n.t("vagrant.sshfs.actions.reverse_mounting_folder",
                           hostpath: hostpath, guestpath: expanded_guest_path))
 
           # Log STDERR to predictable files so that we can inspect them
@@ -104,7 +104,7 @@ module VagrantPlugins
 
           # Launch sshfs command to mount guest dir into the host
           if Vagrant::Util::Platform.windows?
-            # Need to handle Windows differently. Kernel.spawn fails to work, 
+            # Need to handle Windows differently. Kernel.spawn fails to work,
             # if the shell creating the process is closed.
             # See https://github.com/dustymabe/vagrant-sshfs/issues/31
             Process.create(:command_line => ssh_cmd,

--- a/lib/vagrant-sshfs/cap/host/linux/sshfs_reverse_mount.rb
+++ b/lib/vagrant-sshfs/cap/host/linux/sshfs_reverse_mount.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
           # opts contains something like:
           #   { :type=>:sshfs,
           #     :guestpath=>"/sharedfolder",
-          #     :hostpath=>"/guests/sharedfolder", 
+          #     :hostpath=>"/guests/sharedfolder",
           #     :disabled=>false
           #     :ssh_host=>"192.168.1.1"
           #     :ssh_port=>"22"
@@ -45,7 +45,7 @@ module VagrantPlugins
 
         protected
 
-        # Perform a mount by running an sftp-server on the vagrant host 
+        # Perform a mount by running an sftp-server on the vagrant host
         # and piping stdin/stdout to sshfs running inside the guest
         def self.sshfs_mount(machine, opts)
 
@@ -63,7 +63,7 @@ module VagrantPlugins
           opts[:sshfs_opts] = ' -o noauto_cache '# disable caching based on mtime
 
           # Add in some ssh options that are common to both mount methods
-          opts[:ssh_opts] = ' -o StrictHostKeyChecking=no '# prevent yes/no question 
+          opts[:ssh_opts] = ' -o StrictHostKeyChecking=no '# prevent yes/no question
           opts[:ssh_opts]+= ' -o ServerAliveInterval=30 '  # send keepalives
 
           # SSH connection options
@@ -87,12 +87,12 @@ module VagrantPlugins
           # The sshfs command to mount the guest directory on the host
           sshfs_cmd = "#{sshfs_path} #{ssh_opts} #{ssh_opts_append} "
           sshfs_cmd+= "#{sshfs_opts} #{sshfs_opts_append} "
-          sshfs_cmd+= "#{username}@#{host}:#{expanded_guest_path} #{hostpath}" 
+          sshfs_cmd+= "#{username}@#{host}:#{expanded_guest_path} #{hostpath}"
 
           # Log some information
           @@logger.debug("sshfs cmd: #{sshfs_cmd}")
 
-          machine.ui.info(I18n.t("vagrant.sshfs.actions.reverse_mounting_folder", 
+          machine.ui.info(I18n.t("vagrant.sshfs.actions.reverse_mounting_folder",
                           hostpath: hostpath, guestpath: expanded_guest_path))
 
           # Log STDERR to predictable files so that we can inspect them
@@ -103,7 +103,7 @@ module VagrantPlugins
 
           # Launch sshfs command to mount guest dir into the host
           if Vagrant::Util::Platform.windows?
-            # Need to handle Windows differently. Kernel.spawn fails to work, 
+            # Need to handle Windows differently. Kernel.spawn fails to work,
             # if the shell creating the process is closed.
             # See https://github.com/dustymabe/vagrant-sshfs/issues/31
             Process.create(:command_line => ssh_cmd,

--- a/lib/vagrant-sshfs/plugin.rb
+++ b/lib/vagrant-sshfs/plugin.rb
@@ -120,6 +120,35 @@ module VagrantPlugins
         VagrantPlugins::GuestSUSE::Cap::SSHFSClient
       end
 
+      guest_capability("freebsd", "sshfs_forward_mount_folder") do
+        require_relative "cap/guest/freebsd/sshfs_forward_mount"
+        VagrantPlugins::GuestFreeBSD::Cap::MountSSHFS
+      end
+
+      guest_capability("freebsd", "sshfs_forward_unmount_folder") do
+        require_relative "cap/guest/freebsd/sshfs_forward_mount"
+        VagrantPlugins::GuestFreeBSD::Cap::MountSSHFS
+      end
+
+      guest_capability("freebsd", "sshfs_forward_is_folder_mounted") do
+        require_relative "cap/guest/freebsd/sshfs_forward_mount"
+        VagrantPlugins::GuestFreeBSD::Cap::MountSSHFS
+      end
+
+      guest_capability("freebsd", "sshfs_get_absolute_path") do
+        require_relative "cap/guest/linux/sshfs_get_absolute_path"
+        VagrantPlugins::GuestLinux::Cap::SSHFSGetAbsolutePath
+      end
+
+      guest_capability("freebsd", "sshfs_install") do
+        require_relative "cap/guest/freebsd/sshfs_client"
+        VagrantPlugins::GuestFreeBSD::Cap::SSHFSClient
+      end
+
+      guest_capability("freebsd", "sshfs_installed") do
+        require_relative "cap/guest/freebsd/sshfs_client"
+        VagrantPlugins::GuestFreeBSD::Cap::SSHFSClient
+      end
     end
   end
 end

--- a/lib/vagrant-sshfs/synced_folder/sshfs_forward_mount.rb
+++ b/lib/vagrant-sshfs/synced_folder/sshfs_forward_mount.rb
@@ -101,7 +101,7 @@ module VagrantPlugins
           if not opts.has_key?(:ssh_password) or not opts[:ssh_password]
             if not ssh_info.has_key?(:forward_agent) or not ssh_info[:forward_agent]
             prompt_for_password = true
-            end 
+            end
           end
 
         # Now do the prompt

--- a/test/misc/Vagrantfile
+++ b/test/misc/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(2) do |config|
     # https://github.com/dustymabe/vagrant-sshfs/issues/44
     config.vm.synced_folder "/etc/", "/sbin/forward_slave_mount_sym_link_test/", type: "sshfs"
 
-    # Test a forward normal mount: 
+    # Test a forward normal mount:
     #     mounting a folder from a 3rd party host into guest
     config.vm.synced_folder "/etc/", "/tmp/forward_normal_mount_etc/", type: "sshfs",
         ssh_host: ENV['THIRD_PARTY_HOST'],


### PR DESCRIPTION
This merge adds support for FreeBSD, tested and working on `bento/freebsd-10.3`

it can install `sshfs` and also loads the fuse kernel module as you need to force it on FreeBSD