### PR TITLE
Run "apt-get update" before attempting to install sshfs in the guest

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/debian/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/debian/sshfs_client.rb
@@ -3,6 +3,7 @@ module VagrantPlugins
     module Cap
       class SSHFSClient
         def self.sshfs_install(machine)
+          machine.communicate.sudo("apt-get update")
           machine.communicate.sudo("apt-get install -y sshfs")
         end
 


### PR DESCRIPTION
Currently this plugin breaks when building guests from a box where `apt-clean` has been run (which seems to be common practice to minimize the size of the box).

This PR causes the plugin to run `apt-get update` before attempting to install sshfs in the guest.