### PR TITLE
add apt-get update to debian sshfs_client

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/debian/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/debian/sshfs_client.rb
@@ -3,6 +3,7 @@ module VagrantPlugins
     module Cap
       class SSHFSClient
         def self.sshfs_install(machine)
+          machine.communicate.sudo("apt-get update")
           machine.communicate.sudo("apt-get install -y sshfs")
         end
 


### PR DESCRIPTION
Call "apt-get update" before installation of sshfs to make sure the package "sshfs" can be found.

Current "ubuntu/xenial" boxes do not have any files in /var/lib/apt/lists/.
So trying to use vagrant-sshfs with these boxes fails with:
```
E: Unable to locate package sshfs
```

Best regards,
Harald