### PR TITLE
Add sshfs installation support for alpine guests

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/alpine/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/alpine/sshfs_client.rb
@@ -1,0 +1,20 @@
+module VagrantPlugins
+  module GuestAlpine
+    module Cap
+      class SSHFSClient
+        def self.sshfs_install(machine)
+          # Install sshfs
+          machine.communicate.sudo("apk add sshfs")
+
+          # Load the fuse module and autoload it in the feature
+          machine.communicate.sudo("modprobe fuse")
+          machine.communicate.sudo("echo fuse >> /etc/modules")
+        end
+
+        def self.sshfs_installed(machine)
+          machine.communicate.test("apk -e info sshfs")
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-sshfs/plugin.rb
+++ b/lib/vagrant-sshfs/plugin.rb
@@ -127,6 +127,16 @@ module VagrantPlugins
         VagrantPlugins::GuestArch::Cap::SSHFSClient
       end
 
+     guest_capability("alpine", "sshfs_installed") do
+        require_relative "cap/guest/alpine/sshfs_client"
+        VagrantPlugins::GuestAlpine::Cap::SSHFSClient
+      end
+
+      guest_capability("alpine", "sshfs_install") do
+        require_relative "cap/guest/alpine/sshfs_client"
+        VagrantPlugins::GuestAlpine::Cap::SSHFSClient
+      end
+
       guest_capability("suse", "sshfs_installed") do
         require_relative "cap/guest/suse/sshfs_client"
         VagrantPlugins::GuestSUSE::Cap::SSHFSClient


### PR DESCRIPTION
While the "alpine" guest type isn't supported in upstream vagrant yet (EDIT: Upstreaming is in the works: hashicorp/vagrant#10975), it is provided by the vagrant-alpine plugin for the time being. Even if the plugin isn't installed, it won't break anything.