### PR TITLE
Use /var/run/ -> /run symlink for tests

### DIFF
--- a/test/misc/Vagrantfile
+++ b/test/misc/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
 
     # Test a forward mount to a location that is a symbolic link
     # https://github.com/dustymabe/vagrant-sshfs/issues/44
-    config.vm.synced_folder "/etc/", "/sbin/forward_slave_mount_sym_link_test/", type: "sshfs"
+    config.vm.synced_folder "/etc/", "/var/run/forward_slave_mount_sym_link_test/", type: "sshfs"
 
     # Test a forward normal mount:
     #     mounting a folder from a 3rd party host into guest

--- a/test/misc/dotests.sh
+++ b/test/misc/dotests.sh
@@ -8,7 +8,7 @@ vagrant ssh -- cat /tmp/forward_slave_mount_etc/machine-id
 
 # https://github.com/dustymabe/vagrant-sshfs/issues/44
 echo -en "Testing slave forward mount with a symlink!\n\t"
-vagrant ssh -- cat /usr/sbin/forward_slave_mount_sym_link_test/machine-id
+vagrant ssh -- cat /run/forward_slave_mount_sym_link_test/machine-id
 
 echo -en "Testing normal forward mount!\n\t"
 vagrant ssh -- cat /tmp/forward_normal_mount_etc/machine-id


### PR DESCRIPTION
The symlink `/var/run -> /run` is more common among different Linux distributions than `/sbin/ -> /usr/sbin`. This makes the testsuite a bit more portable when swapping the vagrant box for one of a different distro.