### PR TITLE
Add CentOS guest support for compatibility with Vagrant v2.2.8+

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/centos/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/centos/sshfs_client.rb
@@ -1,0 +1,35 @@
+module VagrantPlugins
+  module GuestCentos
+    module Cap
+      class SSHFSClient
+        def self.sshfs_install(machine)
+
+          case machine.guest.capability("flavor")
+            when :centos_8
+              machine.communicate.sudo("yum -y install --enablerepo=PowerTools fuse-sshfs")
+            when :centos_7, :centos
+              if !epel_installed(machine)
+                epel_install(machine)
+              end
+              machine.communicate.sudo("yum -y install fuse-sshfs")
+          end
+        end
+
+        def self.sshfs_installed(machine)
+          machine.communicate.test("rpm -q fuse-sshfs")
+        end
+
+        protected
+
+        def self.epel_installed(machine)
+          machine.communicate.test("rpm -q epel-release")
+        end
+
+        def self.epel_install(machine)
+          machine.communicate.sudo("yum -y install epel-release")
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vagrant-sshfs/plugin.rb
+++ b/lib/vagrant-sshfs/plugin.rb
@@ -97,6 +97,16 @@ module VagrantPlugins
         VagrantPlugins::GuestRedHat::Cap::SSHFSClient
       end
 
+      guest_capability("centos", "sshfs_installed") do
+        require_relative "cap/guest/centos/sshfs_client"
+        VagrantPlugins::GuestCentos::Cap::SSHFSClient
+      end
+
+      guest_capability("centos", "sshfs_install") do
+        require_relative "cap/guest/centos/sshfs_client"
+        VagrantPlugins::GuestCentos::Cap::SSHFSClient
+      end
+
       guest_capability("fedora", "sshfs_installed") do
         require_relative "cap/guest/fedora/sshfs_client"
         VagrantPlugins::GuestFedora::Cap::SSHFSClient


### PR DESCRIPTION
Vagrant 2.2.8 introduced explicit handling of CentOS as a guest in the commit https://github.com/hashicorp/vagrant/commit/5104d075bdeb8670db7aff6c8247506e6ca28a63

This causes the vagrant-sshfs plugin to skip the installation of fuse-sshfs because the returned value of `machine.guest.capability("flavor")` is now `:centos`, `:centos_7`, or `:centos_8` depending on the version of the guest machine.  A consequence of this is that any attempt to mount any folder via sshfs fails.

This change introduces handling for CentOS to fix this problem in versions of Vagrant from 2.2.8 onwards.