### PR TITLE
synced_folder: Add directory for SUSE/openSUSE to find sftp-server

### DIFF
--- a/lib/vagrant-sshfs/synced_folder.rb
+++ b/lib/vagrant-sshfs/synced_folder.rb
@@ -110,6 +110,7 @@ module VagrantPlugins
             ENV['PATH'] += ';C:\cygwin64\usr\sbin'
           end
         else
+          ENV['PATH'] += ':/usr/libexec/ssh'     # Linux (openSUSE/SUSE Family)
           ENV['PATH'] += ':/usr/libexec/openssh' # Linux (Red Hat Family)
           ENV['PATH'] += ':/usr/lib/openssh'     # Linux (Debian Family)
           ENV['PATH'] += ':/usr/lib/ssh'         # Linux (Arch Linux Family)


### PR DESCRIPTION
SUSE/openSUSE distributions traditionally used /usr/lib/ssh as
location for the sftp-server. In an attempt to closer align to
FHS 3.0, the location has been changed to /usr/libexec/ssh