### PR TITLE
Enable sftp subsystem on openSUSE if it is not enabled

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/suse/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/suse/sshfs_client.rb
@@ -4,6 +4,7 @@ module VagrantPlugins
       class SSHFSClient
         def self.sshfs_install(machine)
           machine.communicate.sudo("zypper -n install sshfs")
+          machine.communicate.sudo('if ! grep -q "^[[:space:]]*Subsystem[[:space:]]\+sftp" /etc/ssh/sshd_config; then echo "Subsystem sftp /usr/libexec/ssh/sftp-server" >> /etc/ssh/sshd_config; systemctl restart sshd; fi')
         end
 
         def self.sshfs_installed(machine)


### PR DESCRIPTION
openSUSE Tumbleweed recently stopped enabling the sftp subsystem in sshd which
breaks using sftp via vagrant-sshfs.
Thus we now check whether the correct subsystem directive is in
`/etc/ssh/sshd_config` and if it missing, then we add it and restart sshd