### PR TITLE
add owner/group support to linux fowrward mount

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
+++ b/lib/vagrant-sshfs/cap/guest/linux/sshfs_forward_mount.rb
@@ -86,6 +86,29 @@ module VagrantPlugins
           opts[:sshfs_opts] = ' -o allow_other ' # allow non-root users to access
           opts[:sshfs_opts]+= ' -o noauto_cache '# disable caching based on mtime
 
+          if opts[:owner]
+            machine.communicate.execute("id -u #{opts[:owner]}") do |type, data|
+              if type == :stdout
+                uid = data.strip!
+                opts[:sshfs_opts]+= " -o uid=#{uid} "
+              elsif type == :stderr
+                machine.ui.error(I18n.t("vagrant.sshfs.errors.failed_to_find_id"))
+              end
+            end
+          end
+
+          if opts[:group]
+            machine.communicate.execute("id -g #{opts[:group]}") do |type, data|
+              if type == :stdout
+                gid = data.strip!
+                opts[:sshfs_opts]+= " -o gid=#{gid} "
+              elsif type == :stderr
+                machine.ui.error(I18n.t("vagrant.sshfs.errors.failed_to_find_id"))
+              end
+            end
+          end
+
+
           # Add in some ssh options that are common to both mount methods
           opts[:ssh_opts] = ' -o StrictHostKeyChecking=no '# prevent yes/no question
           opts[:ssh_opts]+= ' -o ServerAliveInterval=30 '  # send keepalives

--- a/locales/synced_folder_sshfs.yml
+++ b/locales/synced_folder_sshfs.yml
@@ -93,3 +93,17 @@ en:
           Stderr from the command:
 
           %{stderr}
+        failed_to_find_id: |-
+          Unable to find owner/group.
+
+          The command and output are:
+
+          %{command}
+
+          Stdout from the command:
+
+          %{stdout}
+
+          Stderr from the command:
+
+          %{stderr}


### PR DESCRIPTION
Hello,

I did a little hack to add support for `owner` and `group` for vagrant-sshfs and thought it might be interesting to merge.

I'm no exprt in ruby and I don't know if you want to actually support it. if there are changes I can do please let me know.

Best Regards,
Skander.