### PR TITLE
adjust kernel module name for FreeBSD

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/freebsd/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/freebsd/sshfs_client.rb
@@ -4,14 +4,14 @@ module VagrantPlugins
       class SSHFSClient
         def self.sshfs_install(machine)
           machine.communicate.sudo("pkg install -y fusefs-sshfs")
-          machine.communicate.sudo("kldload fuse")
+          machine.communicate.sudo("kldload fusefs")
         end
 
         def self.sshfs_installed(machine)
           installed = machine.communicate.test("pkg info fusefs-sshfs")
           if installed
               # fuse may not get loaded at boot, so check if it's loaded otherwise force load it
-              machine.communicate.sudo("kldstat -m fuse || kldload fuse")
+              machine.communicate.sudo("kldstat -m fusefs || kldload fusefs")
           end
 
           installed


### PR DESCRIPTION
It is called "fusefs", not "fuse" anymore.