### PR TITLE
Add guest capabilities file for Rocky Linux

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/rocky/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/rocky/sshfs_client.rb
@@ -1,0 +1,23 @@
+module VagrantPlugins
+  module GuestRocky
+    module Cap
+      class SSHFSClient
+        def self.sshfs_install(machine)
+
+          case machine.guest.capability("flavor")
+            when :rocky_8
+              # No need to install epel. fuse-sshfs comes from the powertools repo
+              # https://bugzilla.redhat.com/show_bug.cgi?id=1758884
+              # https://github.com/dustymabe/vagrant-sshfs/issues/123
+              machine.communicate.sudo("yum -y install --enablerepo=powertools fuse-sshfs")
+          end
+        end
+
+        def self.sshfs_installed(machine)
+          machine.communicate.test("rpm -q fuse-sshfs")
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vagrant-sshfs/cap/guest/rocky/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/rocky/sshfs_client.rb
@@ -3,14 +3,10 @@ module VagrantPlugins
     module Cap
       class SSHFSClient
         def self.sshfs_install(machine)
-
-          case machine.guest.capability("flavor")
-            when :rocky_8
-              # No need to install epel. fuse-sshfs comes from the powertools repo
-              # https://bugzilla.redhat.com/show_bug.cgi?id=1758884
-              # https://github.com/dustymabe/vagrant-sshfs/issues/123
-              machine.communicate.sudo("yum -y install --enablerepo=powertools fuse-sshfs")
-          end
+          # No need to install epel. fuse-sshfs comes from the powertools repo
+          # https://bugzilla.redhat.com/show_bug.cgi?id=1758884
+          # https://github.com/dustymabe/vagrant-sshfs/issues/123
+          machine.communicate.sudo("yum -y install --enablerepo=powertools fuse-sshfs")
         end
 
         def self.sshfs_installed(machine)

--- a/lib/vagrant-sshfs/plugin.rb
+++ b/lib/vagrant-sshfs/plugin.rb
@@ -107,6 +107,16 @@ module VagrantPlugins
         VagrantPlugins::GuestCentOS::Cap::SSHFSClient
       end
 
+      guest_capability("rocky", "sshfs_installed") do
+        require_relative "cap/guest/rocky/sshfs_client"
+        VagrantPlugins::GuestRocky::Cap::SSHFSClient
+      end
+
+      guest_capability("rocky", "sshfs_install") do
+        require_relative "cap/guest/rocky/sshfs_client"
+        VagrantPlugins::GuestRocky::Cap::SSHFSClient
+      end
+
       guest_capability("fedora", "sshfs_installed") do
         require_relative "cap/guest/fedora/sshfs_client"
         VagrantPlugins::GuestFedora::Cap::SSHFSClient


### PR DESCRIPTION
Thanks for creating this great plugin! 

This PR adds guest capabilities file for Rocky Linux 8. It's basically a copy/paste job from the `:centos_8` part of the centos capabilities, but with the 6 and 7 case/when statement removed since it doesn't apply to Rocky (which launched with version 8).

Let me know if this lacks something or is incomplete in some way.

---

<details>
<summary>My setup (if it's relevant):</summary>

Since vagrant-libvirt doesn't work with the upstream package on Fedora 35 (and the Fedora-provided package is 2.2.16 (which doesn't support Rocky guests)), I built a Vagrant Podman container like this:

```bash
#!/bin/bash -x
container=$(buildah from "fedora:rawhide")
buildah run "$container" -- dnf install -y openssh-server openssh-clients vagrant vagrant-libvirt
buildah run "$container" -- dnf clean all
buildah commit "$container" "vagrant"
```
Then after executing this, I run the container:

```bash
podman run --rm -it \
  --volume /run/libvirt:/run/ \ 
  --volume "${HOME}:${HOME}:rslave" \ 
  -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK \ 
  -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
  --env "HOME=${HOME}" \
  --workdir "$(pwd)" \
  --net host \
  --privileged \
  --security-opt label=disable \ 
  localhost/vagrant:latest
```

Then I installed my locally built gem inside the container with `vagrant plugin install ./vagrant-sshfs-1.3.6.gem`.

Relevant part of my Vagrantfile:

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "generic/rocky8"
  config.vm.network :forwarded_port, guest: 3000, host: 3000
  config.vm.network :private_network, type: "dhcp"
  config.ssh.forward_agent = true
  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
  config.vm.provider :libvirt do |lv|
    lv.qemu_use_session = false
  end
end
```
</details>