### PR TITLE
guest: epel repo might be disabled on CentOS

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/centos/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/centos/sshfs_client.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
               if !epel_installed(machine)
                 epel_install(machine)
               end
-              machine.communicate.sudo("yum -y install fuse-sshfs")
+              machine.communicate.sudo("yum -y --enablerepo=epel install fuse-sshfs")
           end
         end
 


### PR DESCRIPTION
`epel.repo` might have setting `enabled=0` so that packages are not quietly installed from it.