### PR TITLE
Synced folder ssh reverse mount ignores ssh_username

### DIFF
--- a/lib/vagrant-sshfs/cap/host/linux/sshfs_reverse_mount.rb
+++ b/lib/vagrant-sshfs/cap/host/linux/sshfs_reverse_mount.rb
@@ -118,7 +118,7 @@ module VagrantPlugins
             sshfs_opts_append+= ' -o ' + mount_options.join(',') + ' '
           end
 
-          username = machine.ssh_info[:username]
+          username = opts.key?(:ssh_username) ? opts[:ssh_username] : machine.ssh_info[:username]
           host = machine.ssh_info[:host]
 
 


### PR DESCRIPTION
It probably ignores ssh_host and ssh_password also, fix is only for
ssh_username