### PR TITLE
Allow non drvfs on wsl environment

### DIFF
--- a/lib/vagrant-sshfs/synced_folder.rb
+++ b/lib/vagrant-sshfs/synced_folder.rb
@@ -126,6 +126,12 @@ module VagrantPlugins
         ENV['PATH'] = oldpath
         return exepath
       end
+
+      # Enable rsync synced folders within WSL when in use
+      # on non-DrvFs file systems
+      def self.wsl_allow_non_drvfs?
+        true
+      end
     end
   end
 end

--- a/lib/vagrant-sshfs/synced_folder.rb
+++ b/lib/vagrant-sshfs/synced_folder.rb
@@ -127,7 +127,7 @@ module VagrantPlugins
         return exepath
       end
 
-      # Enable rsync synced folders within WSL when in use
+      # Enable sshfs synced folders within WSL when in use
       # on non-DrvFs file systems
       def self.wsl_allow_non_drvfs?
         true


### PR DESCRIPTION
Hi Preact team!

I have been using vagrant-sshfs on a regular basis!

This time, I want to use this plugin in a wsl environment.

To do so, I need to set the `wsl_allow_non_drvfs` option to `true`, so I created this PR based on the official vagrant rsycn shared folder plugin example.

Official Example: 

https://github.com/hashicorp/vagrant/blob/5b501a3fb05ed0ab16cf10991b3df9d231edb5cf/plugins/synced_folders/rsync/synced_folder.rb#L52-L56

Thank you.