### PR TITLE
Respect RPM provides

### DIFF
--- a/lib/vagrant-sshfs/cap/guest/alma/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/alma/sshfs_client.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
         end
 
         def self.sshfs_installed(machine)
-          machine.communicate.test("rpm -q fuse-sshfs")
+          machine.communicate.test("rpm -q --whatprovides fuse-sshfs")
         end
 
         protected

--- a/lib/vagrant-sshfs/cap/guest/centos/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/centos/sshfs_client.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
         end
 
         def self.sshfs_installed(machine)
-          machine.communicate.test("rpm -q fuse-sshfs")
+          machine.communicate.test("rpm -q --whatprovides fuse-sshfs")
         end
 
         protected

--- a/lib/vagrant-sshfs/cap/guest/fedora/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/fedora/sshfs_client.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         end
 
         def self.sshfs_installed(machine)
-          machine.communicate.test("rpm -q fuse-sshfs")
+          machine.communicate.test("rpm -q --whatprovides fuse-sshfs")
         end
       end
     end

--- a/lib/vagrant-sshfs/cap/guest/redhat/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/redhat/sshfs_client.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
         end
 
         def self.sshfs_installed(machine)
-          machine.communicate.test("rpm -q fuse-sshfs")
+          machine.communicate.test("rpm -q --whatprovides fuse-sshfs")
         end
 
         protected

--- a/lib/vagrant-sshfs/cap/guest/rocky/sshfs_client.rb
+++ b/lib/vagrant-sshfs/cap/guest/rocky/sshfs_client.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
         end
 
         def self.sshfs_installed(machine)
-          machine.communicate.test("rpm -q fuse-sshfs")
+          machine.communicate.test("rpm -q --whatprovides fuse-sshfs")
         end
 
         protected


### PR DESCRIPTION
In ROSA Linux sshfs is named as sshfs-fuse, not fuse-sshfs, but provides "sshfs" and "fuse-sshfs":
https://abf.io/import/sshfs-fuse/blob/4c22a0a852/sshfs-fuse.spec#lc-20
Do not fail in such cases.